### PR TITLE
Restore the old (scheme less) mqtt server url configuration support

### DIFF
--- a/main/eq3_helper.c
+++ b/main/eq3_helper.c
@@ -1,0 +1,14 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "eq3_helper.h"
+
+#define HELPER_TAG "EQ3_HELPER"
+
+bool isLegacyMqttUrl( const char s[] )
+{
+	char *index = strstr(s, "://");
+
+    return (index == NULL);
+}

--- a/main/eq3_helper.h
+++ b/main/eq3_helper.h
@@ -1,0 +1,6 @@
+#ifndef EQ3_HELPER_H
+#define EQ3_HELPER_H
+
+bool isLegacyMqttUrl( const char s[] );
+
+#endif

--- a/main/eq3_wifi.c
+++ b/main/eq3_wifi.c
@@ -38,6 +38,7 @@
 
 #include "eq3_wifi.h"
 #include "eq3_gap.h"
+#include "eq3_helper.h"
 
 #ifdef removed
 /* FreeRTOS event group to signal when we are connected & ready to make a request */
@@ -209,11 +210,20 @@ int send_device_list(char *list){
 }
 
 static char lwt_topic_buff[38];
+static char mqtt_url_buff[256];
 
 int connect_server(char *url, char *user, char *password, char *id){
 	sprintf(lwt_topic_buff, "/%sradout", id);
 	sprintf(intopicbase, "/%sradin", id);
 	sprintf(outtopicbase, "/%sradout", id);
+
+	if(isLegacyMqttUrl(url))
+	{
+		char *prefixMqtt = "mqtt://";
+		sprintf(mqtt_url_buff, "%s%s", prefixMqtt, url);
+		ESP_LOGI(MQTT_TAG, "Use legacy fallback for mqtt-url: %s", mqtt_url_buff);
+		url = mqtt_url_buff;
+	}
 
 	esp_mqtt_client_config_t settings = {
 		#if defined(CONFIG_MQTT_SECURITY_ON)

--- a/main/eq3_wifi.h
+++ b/main/eq3_wifi.h
@@ -3,7 +3,7 @@
 #define EQ3_WIFI_H
 
 #define EQ3_MAJVER "1"
-#define EQ3_MINVER "20"
+#define EQ3_MINVER "30"
 
 void initialise_wifi(void);
 


### PR DESCRIPTION
Restore support for legacy mqtt server urls (without scheme) as it used by the old mqtt libary