### PR TITLE
Change "eco" to "holiday" mode because it was misinterpreted

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ This can be used as an acknowledgement of a successful command to remote mqtt cl
 | trv | Bluetooth-Address of the corroesponding thermostat | `"trv":"ab:cd:ef:gh:ij:kl"` | 1.20 |
 | temp | the current target room-temperature is set | `"temp":"20.0"` | 1.20 |
 | offsetTemp | the current offset temperature is set | `"offsetTemp":"0.0"` | 1.30 (upstream merge in dev) |
-| mode | the current thermostate programm mode<br><br>`"auto"` = internal temperature/time program is used<br>`"eco"` = internal temperature/time program is used and eco mode is currently active<br>`"manual"` = internal temperature/time program is disabled | `"mode":"auto"`<br> `"mode":"eco"`<br> `"mode":"manual"` | 1.20 |
+| mode | the current thermostate programm mode<br><br>`"auto"` = internal temperature/time program is used<br>`"manual"` = internal temperature/time program is disabled<br>`"holiday"` = holiday mode is used | `"mode":"auto"`<br> `"mode":"manual"`<br> `"mode":"holiday"` | 1.20 <sup>1)</sup> |
 | boost | boost-mode is active / inactiv | `"boost"`:`"active"`<br>`"boost"`:`"inactive"` | 1.20 |
 | state | front-panel controls are locked / unlocked | `"state"`:`"locked"`<br>`"state"`:`"unlocked"` | 1.20 |
 | battery | battery state | `"battery"`:`"GOOD"`<br>`"battery"`:`"LOW"` | 1.20 |
+<sup>1)</sup> Changed in current dev-branch: `"eco"` is removed because it was misinterpreted
 
 ### Read current status
 

--- a/main/eq3_main.c
+++ b/main/eq3_main.c
@@ -526,8 +526,8 @@ static void gattc_profile_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
                     ESP_LOGI(GATTC_TAG, "eq3 set manual");
                     statidx += sprintf(&statrep[statidx], "\"manual\"");
                 }else if(tempval & AWAY){
-                    ESP_LOGI(GATTC_TAG, "eq3 set eco");
-                    statidx += sprintf(&statrep[statidx], "\"eco\"");
+                    ESP_LOGI(GATTC_TAG, "eq3 set holiday");
+                    statidx += sprintf(&statrep[statidx], "\"holiday\"");
                 }else{
                     ESP_LOGI(GATTC_TAG, "eq3 set auto");
                     statidx += sprintf(&statrep[statidx], "\"auto\"");


### PR DESCRIPTION
The Bit 1 in byte 2 off the status notification is misinterpreted as "eco" mode. But its indicate the "holiday" mode.

e.g.:
 ```
  # Status notification for day-mode (manual mode is active)
  Notification handle = 0x0421 value: 02 01 09 00 04 22 00 00 00 00 18 03 2c 24 06


 # Status notification for eco/night-mode
  Notification handle = 0x0421 value: 02 01 09 00 04 2a 00 00 00 00 18 03 2c 24 06

  # Status notification if holiday mode is enabled
  Notification handle = 0x0421 value: 02 01 0A 00 04 22 00 00 00 00 18 03 2c 24 06

  # Status notification if holiday mode ends (manual mode is now active again)
  Notification handle = 0x0421 value: 02 01 09 00 04 22 00 00 00 00 18 03 2c 24 06
```

You see that byte 2 is doesn't changing if you switch between day and eco/night mode. But it switch to 0x0A if you enable holiday mode and back, if holiday mode ends.

There isn't any bit with indicate the currently the "day" or the "eco"/"night" mode is active. the only possible solution for this would be to read and save the required temp, switch to both modes and read the temps, compare the temp read with required temp and at least, set again the original required temp