### PR TITLE
Don't enqueue the same command again if it still is the last command

### DIFF
--- a/main/eq3_main.c
+++ b/main/eq3_main.c
@@ -566,7 +566,8 @@ static void gattc_profile_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         /* Disconnected */
         get_server = false;
         ESP_LOGI(GATTC_TAG, "ESP_GATTC_DISCONNECT_EVT, status = %d", p_data->disconnect.reason);
-	    //esp_ble_gattc_app_unregister(gl_profile_tab[PROFILE_A_APP_ID].gattc_if);
+        //esp_ble_gattc_app_unregister(gl_profile_tab[PROFILE_A_APP_ID].gattc_if);
+        ble_operation_in_progress = false;
         break;
     default:
         ESP_LOGI(GATTC_TAG, "Unhandled_EVT %d", event);
@@ -1149,7 +1150,7 @@ void app_main(){
 	
 	    /* Timer message handling */
 	    if(xQueueReceive(timer_queue, &evt, 0)){
-            ESP_LOGI(GATTC_TAG, "Timer0 event");
+            ESP_LOGI(GATTC_TAG, "Timer0 event (nextcmd.running=%d, ble_operation_in_progress=%d)", nextcmd.running, ble_operation_in_progress);
             outstanding_timer = false;
             
             if(nextcmd.running == true){
@@ -1162,7 +1163,6 @@ void app_main(){
                                 esp_ble_gattc_close (gl_profile_tab[PROFILE_A_APP_ID].gattc_if, gl_profile_tab[PROFILE_A_APP_ID].conn_id);
                             }
                             runtimer();
-                            ble_operation_in_progress = false;
                             break;
                         case START_WIFI:
                             ESP_LOGI(GATTC_TAG, "Init wifi");


### PR DESCRIPTION
Since we have a working and good command retry solution, we run in a new issue.
If someone sends the command every minute (like `unlock`) and the trv is far away, we maybe get multiple timeouts until command proceeds. if this needs more then a minute (in this example) the same command is added ever and ever again.

this patch extracts the enqueue code in a new function and makes a simple check. it prevents the command to be added to the queue if it still is the last command for a specific trv.

the code is tested in a stress test with my 2 test trvs for a full hower without any problems.