### PR TITLE
Fix a bug that results in that the command queue is no longer processed

### DIFF
--- a/main/eq3_main.c
+++ b/main/eq3_main.c
@@ -566,7 +566,8 @@ static void gattc_profile_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         /* Disconnected */
         get_server = false;
         ESP_LOGI(GATTC_TAG, "ESP_GATTC_DISCONNECT_EVT, status = %d", p_data->disconnect.reason);
-	    //esp_ble_gattc_app_unregister(gl_profile_tab[PROFILE_A_APP_ID].gattc_if);
+        //esp_ble_gattc_app_unregister(gl_profile_tab[PROFILE_A_APP_ID].gattc_if);
+        ble_operation_in_progress = false;
         break;
     default:
         ESP_LOGI(GATTC_TAG, "Unhandled_EVT %d", event);
@@ -1119,7 +1120,7 @@ void app_main(){
 	
 	    /* Timer message handling */
 	    if(xQueueReceive(timer_queue, &evt, 0)){
-            ESP_LOGI(GATTC_TAG, "Timer0 event");
+            ESP_LOGI(GATTC_TAG, "Timer0 event (nextcmd.running=%d, ble_operation_in_progress=%d)", nextcmd.running, ble_operation_in_progress);
             outstanding_timer = false;
             
             if(nextcmd.running == true){
@@ -1132,7 +1133,6 @@ void app_main(){
                                 esp_ble_gattc_close (gl_profile_tab[PROFILE_A_APP_ID].gattc_if, gl_profile_tab[PROFILE_A_APP_ID].conn_id);
                             }
                             runtimer();
-                            ble_operation_in_progress = false;
                             break;
                         case START_WIFI:
                             ESP_LOGI(GATTC_TAG, "Init wifi");

--- a/main/eq3_main.c
+++ b/main/eq3_main.c
@@ -568,6 +568,10 @@ static void gattc_profile_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         ESP_LOGI(GATTC_TAG, "ESP_GATTC_DISCONNECT_EVT, status = %d", p_data->disconnect.reason);
         //esp_ble_gattc_app_unregister(gl_profile_tab[PROFILE_A_APP_ID].gattc_if);
         ble_operation_in_progress = false;
+
+        if(p_data->disconnect.reason != ESP_GATT_CONN_TERMINATE_LOCAL_HOST)
+            gattc_command_error(gl_profile_tab[PROFILE_A_APP_ID].remote_bda, "TRV error");
+
         break;
     default:
         ESP_LOGI(GATTC_TAG, "Unhandled_EVT %d", event);

--- a/main/eq3_main.c
+++ b/main/eq3_main.c
@@ -916,10 +916,15 @@ static int setup_command(void){
 static int command_complete(bool success){
     bool deletehead = false;
     int rc = EQ3_CMD_RETRY;
+
     if(success == true){
         deletehead = true;
         rc = EQ3_CMD_DONE;
-    }else{
+    }
+    else if(cmdqueue == NULL) {
+        rc = EQ3_CMD_DONE;
+    }
+    else{
         /* Command failed - retry if there are any retries left */
         
         /* Normal operation - retry the same command until all attempts are exhausted 
@@ -948,7 +953,7 @@ static int command_complete(bool success){
 #endif  
         }
     }
-    if(deletehead){
+    if(deletehead && cmdqueue != NULL){
         /* Delete this command from the queue */
         struct eq3cmd *delcmd = cmdqueue;
 	    cmdqueue = cmdqueue->next;


### PR DESCRIPTION
I found a bug during my stress testing that blocks the processing of the command queue.
In this case `nextcmd.running` is 0 and `ble_operation_in_progress` is 1 and this will never be changed.

in this state, the command queue will never be continued. new commands would be enqueued but also not executed. this results in an **out of memory crash** after some hours.