### PR TITLE
fix offset value calculation (arithmetic version)

### DIFF
--- a/main/eq3_main.c
+++ b/main/eq3_main.c
@@ -478,15 +478,19 @@ static void gattc_profile_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
                 statidx += sprintf(&statrep[statidx], "\"temp\":\"%d.%d\"", tempval, temphalf);
             }
             if(p_data->notify.value_len >= 14){
-                int8_t offsetval, offsethalf = 0;
-                offsetval = p_data->notify.value[14];
-                offsetval -= 7; // The offset temperature is encoded in steps of 0.5°C between -3.5°C and 3.5°C
-
-                if(offsetval & 0x01)
-                    offsethalf = 5;
-                offsetval >>= 1;
-                ESP_LOGI(GATTC_TAG, "eq3 offsettemp is %d.%d C", offsetval, offsethalf);
-                statidx += sprintf(&statrep[statidx], ",\"offsetTemp\":\"%d.%d\"", offsetval, offsethalf);
+                tempval = p_data->notify.value[14];
+		
+		// The offset temperature is encoded in steps of 0.5°C between -3.5°C and 3.5°C
+                int offsetval = tempval-7; // new value area -7 to 7
+                offsetval *= ((offsetval>0) - (offsetval<0)); // if offsetval > 0 then *=(1-0) else *=(0-1) -> equivalent to offsetval = abs(offsetval)
+                offsetval >>= 1; // shift one bit left means -3 to 3
+		
+                int offsethalf = (1 - (tempval & 0x01)) * 5; // if bit 0 is not set, then we have a half value -> equivalent to if((tempval & 0x01) == 0) offsethalf = 5
+		
+                bool neg = (tempval <= 0x06);
+		
+                ESP_LOGI(GATTC_TAG, "eq3 offsettemp is %s%d.%d C", neg ? "-" : "", offsetval, offsethalf);
+                statidx += sprintf(&statrep[statidx], ",\"offsetTemp\":\"%s%d.%d\"", neg ? "-" : "", offsetval, offsethalf);
             }
             if(p_data->notify.value_len > 3){
                 tempval = p_data->notify.value[3];


### PR DESCRIPTION
this patch reimplements the offset calculation to get it right. Fixes #44

i found arithmetic version without any jumps but this is a little bit harder to read in compare to #47 

please Paul decide which version you want to adopt

i test it again with all possible values with my local c compiler at work (without the xtensa tool chain)

    00 = -3.5
    01 = -3.0
    02 = -2.5
    03 = -2.0
    04 = -1.5
    05 = -1.0
    06 = -0.5
    07 =  0.0
    08 =  0.5
    09 =  1.0
    0A =  1.5
    0B =  2.0
    0C =  2.5
    0D =  3.0
    0E =  3.5
